### PR TITLE
fix: change url path for send signal

### DIFF
--- a/src/cloud.ts
+++ b/src/cloud.ts
@@ -285,7 +285,7 @@ export class Cloud {
    * Send infrared signal.
    */
   public async sendSignal(signalId: string) {
-    const response = await this._post(`/1/signals/${signalId}`)
+    const response = await this._post(`/1/signals/${signalId}/send`)
     return response
   }
 


### PR DESCRIPTION
I tried moving A and it didn't work (getting 404 error).

According to the API docs, the URL path seems to be different so I fixed it and worked fine.

https://swagger.nature.global/#/default/post_1_signals__signal__send

