### PR TITLE
fix: getSensorValue() error with Nature Remo mini

### DIFF
--- a/src/cloud.ts
+++ b/src/cloud.ts
@@ -64,7 +64,7 @@ export class Cloud {
   }
 
   /**
-   * get sensor value of arbitorary device
+   * get sensor value of arbitorary device. "humidity" and "illumination" will be undefined if Nature Remo mini
    */
   public async getSensorValue(): Promise<NatureRemo.ISensorValue> {
     const device = await this.getDevices()

--- a/src/cloud.ts
+++ b/src/cloud.ts
@@ -69,8 +69,8 @@ export class Cloud {
   public async getSensorValue(): Promise<NatureRemo.ISensorValue> {
     const device = await this.getDevices()
     return {
-      humidity: device[0].newest_events.hu.val,
-      illumination: device[0].newest_events.il.val,
+      humidity: device[0].newest_events.hu?.val,
+      illumination: device[0].newest_events.il?.val,
       temperature: device[0].newest_events.te.val,
     } as NatureRemo.ISensorValue
   }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -11,8 +11,8 @@ export interface IDetectedAirconModel {
 
 export interface ISensorValue {
   temperature: number
-  humidity: number
-  illumination: number
+  humidity: number | undefined
+  illumination: number | undefined
 }
 
 export interface IDevice {


### PR DESCRIPTION
Nature Remo mini doesn't have humidity and illumination sensors so `getSensorValue()` with Remo mini throws `TypeError: Cannot read property 'val' of undefined`

Now they will be `undefined` if `hu` `il` is undefined

```js
{
  temperature: 24,
  humidity: undefined,
  illumination: undefined
}
```

I only have Remo mini, don't have regular Remo..., so this wasn't tested with regular Remo; sry